### PR TITLE
feat: add Plugins docs section

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1,11 +1,11 @@
 {
   "$schema": "https://mintlify.com/docs.json",
-  "theme": "maple",
+  "theme": "mint",
   "name": "Cesto",
   "colors": {
-    "primary": "#4ADE80",
-    "light": "#4ADE80",
-    "dark": "#4ADE80"
+    "primary": "#16A34A",
+    "light": "#16A34A",
+    "dark": "#16A34A"
   },
   "favicon": "https://res.cloudinary.com/dcyihhgo6/image/upload/cesto_favicon.png",
   "seo": {
@@ -17,9 +17,9 @@
     }
   },
   "navigation": {
-    "anchors": [
+    "tabs": [
       {
-        "anchor": "Documentation",
+        "tab": "Documentation",
         "icon": "book-open",
         "groups": [
           {
@@ -52,7 +52,7 @@
         ]
       },
       {
-        "anchor": "Developers",
+        "tab": "Developers",
         "icon": "code",
         "groups": [
           {
@@ -67,17 +67,22 @@
             ]
           }
         ]
+      },
+      {
+        "tab": "Plugins",
+        "icon": "puzzle-piece",
+        "groups": [
+          {
+            "group": "Plugins",
+            "pages": [
+              "plugins/overview",
+              "plugins/usage",
+              "plugins/playground"
+            ]
+          }
+        ]
       }
-    ],
-    "global": {
-      "anchors": [
-        {
-          "anchor": "Website",
-          "href": "https://cesto.co",
-          "icon": "globe"
-        }
-      ]
-    }
+    ]
   },
   "logo": {
     "light": "https://res.cloudinary.com/dcyihhgo6/image/upload/cesto-logo.svg",

--- a/plugins/overview.mdx
+++ b/plugins/overview.mdx
@@ -1,0 +1,43 @@
+---
+title: "Overview"
+icon: "puzzle-piece"
+description: "Drop-in plugins for showing any Cesto basket on your site, blog, or app. No React, no build step, no bundle to ship."
+---
+
+Cesto Plugins are self-contained, on-brand UI surfaces that show any basket as a live, interactive card on your page. Each plugin is a single URL you load inside an `<iframe>`. There is no JavaScript to install, no SDK to wire up. Pick a layout, point it at a basket, give it a width, and you have a complete basket experience: banner, chart, allocation, and the Invest CTA.
+
+Use them anywhere you would normally hand-build a "tracker" or "card" component, like newsletters, partner sites, landing pages, and dashboards. The plugin handles data, theming, animations, and routing to invest. You just decide where it sits and how wide it should be.
+
+## Three pages, in order
+
+1. **This page (Overview).** A look at the four available plugins, so you can pick the one that fits your layout.
+2. **[Usage](/plugins/usage).** The single URL pattern, an embed snippet to copy, and the aspect ratio / minimum width for each plugin.
+3. **[Playground](/plugins/playground).** A live preview where you can try every plugin against every basket and copy the exact embed code for the combination you want.
+
+## The four plugins
+
+<CardGroup cols={2}>
+  <Card title="Hero card" icon="image">
+    Full-bleed editorial card with banner, title, return, holder stack, and Invest CTA. Best for landing sections.
+  </Card>
+  <Card title="Performance" icon="chart-line">
+    Photo, multi-timeframe chart, and allocation donut. A three-pane analytics surface that prefetches every timeframe so tab switches are instant.
+  </Card>
+  <Card title="Overview" icon="circle-half-stroke">
+    Banner, allocation donut, every holding as a pill, and the Invest CTA. The default discovery card.
+  </Card>
+  <Card title="Pill row" icon="ellipsis">
+    Inline horizontal pill with avatar, name, return, and Invest. Designed for article rows and feed entries.
+  </Card>
+</CardGroup>
+
+## Next
+
+<CardGroup cols={2}>
+  <Card title="Usage" icon="book" href="/plugins/usage">
+    Plugin URLs, embed snippet, aspect ratios, and sizing.
+  </Card>
+  <Card title="Playground" icon="circle-play" href="/plugins/playground">
+    Pick a basket, switch layouts, and see every plugin live.
+  </Card>
+</CardGroup>

--- a/plugins/playground.mdx
+++ b/plugins/playground.mdx
@@ -15,11 +15,11 @@ mode: "wide"
 Pick a basket on the left, choose a layout, and the preview on the right updates instantly. The copy-paste embed snippet below the design list is the exact code to drop into your own page.
 
 <Note>
-  Want more room? **[Open the playground in a new tab](http://localhost:4000)** for the full-screen view. If the embed below ever appears blank, your browser is blocking third-party content and the new tab will load it fine.
+  Want more room? **[Open the playground in a new tab](https://plugin.cesto.co/playground)** for the full-screen view. If the embed below ever appears blank, your browser is blocking third-party content and the new tab will load it fine.
 </Note>
 
 <iframe
-  src="http://localhost:4000"
+  src="https://plugin.cesto.co/playground"
   title="Cesto Plugin Playground"
   style={{
     display: "block",

--- a/plugins/playground.mdx
+++ b/plugins/playground.mdx
@@ -1,0 +1,45 @@
+---
+title: "Playground"
+icon: "circle-play"
+description: "Try every plugin live, against any basket, right inside the docs."
+mode: "wide"
+---
+
+{/* Marker so the playground-only widening rules in /style.css can scope
+    themselves via .mdx-content:has(.cesto-pg-page). Widening the content
+    column (rather than breaking the iframe out with viewport math) keeps
+    the page responsive: the text and the iframe share one column width at
+    every breakpoint. */}
+<div className="cesto-pg-page" style={{ display: "none" }} />
+
+Pick a basket on the left, choose a layout, and the preview on the right updates instantly. The copy-paste embed snippet below the design list is the exact code to drop into your own page.
+
+<Note>
+  Want more room? **[Open the playground in a new tab](http://localhost:4000)** for the full-screen view. If the embed below ever appears blank, your browser is blocking third-party content and the new tab will load it fine.
+</Note>
+
+<iframe
+  src="http://localhost:4000"
+  title="Cesto Plugin Playground"
+  style={{
+    display: "block",
+    width: "100%",
+    height: "640px",
+    border: "1px solid rgba(255, 255, 255, 0.08)",
+    borderRadius: "12px",
+    overflow: "hidden",
+    background: "#0b0d10",
+    margin: "1.5rem 0",
+  }}
+  allow="clipboard-write"
+/>
+
+## What you can do here
+
+1. **Switch layouts.** The four cards under DESIGNS are the four plugins. Click any of them and the preview re-renders with the new layout.
+2. **Switch baskets.** The dropdown under BASKET lists every published basket. The preview, the embed snippet, and the URL all update together.
+3. **Copy the embed snippet.** Below the design list, the EMBED SNIPPET box has the exact `<iframe>` HTML for the current selection. Click the copy icon, paste it into your page, and you are done.
+4. **Resize and watch it reflow.** Drag the docs window narrower or wider to see each plugin scale itself through CSS container queries. There is no breakpoint cliff; the layout adapts continuously.
+5. **Try the Performance timeframes.** On the Performance preset, click between **1M / 3M / 6M / 1Y**. The first switch fetches, the rest are instant because every timeframe is prefetched in the background.
+
+

--- a/plugins/usage.mdx
+++ b/plugins/usage.mdx
@@ -1,0 +1,95 @@
+---
+title: "Usage"
+icon: "book"
+description: "How to embed a Cesto plugin on your page. One URL, one iframe tag, and the width is yours."
+---
+
+This page is everything you need to embed a plugin on your page. The whole integration is one URL inside an `<iframe>` tag. There is no JavaScript to install and no events to listen for. Pick a plugin, point it at a basket, choose a width, and you are done.
+
+## The URL
+
+```
+https://app.cesto.co/plugin/<plugin-url-path>/?basket=<slug>
+```
+
+`<plugin-url-path>` is one of `hero-card`, `performance`, `overview`, or `pill-row`. `<slug>` is the basket's slug, which is the same value used in `app.cesto.co/product/<slug>`.
+
+## The four plugins
+
+| Plugin | `<plugin-url-path>` | Aspect ratio | Min width |
+|---|---|---|---|
+| Hero card | `hero-card` | 5 : 4 | 360 px |
+| Performance | `performance` | 15 : 8 | 540 px |
+| Overview | `overview` | 2 : 1 | 480 px |
+| Pill row | `pill-row` | 15 : 2 | 300 px |
+
+Aspect ratio is the recommended shape. Min width is the floor below which the plugin starts shedding affordances (the Invest text collapses to an arrow, allocation pills hide, and so on). The plugin still paints below that floor, it just simplifies.
+
+## Embed snippet
+
+Drop this into any HTML page. Replace `hero-card` and `ai-leaders` with the plugin and basket slug you want.
+
+```html
+<iframe
+  src="https://app.cesto.co/plugin/hero-card/?basket=ai-leaders"
+  style="width: 100%; aspect-ratio: 5 / 4; border: 0;"
+  loading="lazy"
+  title="AI Leaders basket"
+></iframe>
+```
+
+That is the entire integration. The plugin fetches its own data, renders the basket, and opens `app.cesto.co/product/<slug>` in a new tab when the user taps Invest.
+
+## Finding a basket slug
+
+Every basket on `app.cesto.co` has a slug in its URL. Open the basket on the website and copy the last path segment, which is the slug:
+
+```
+https://app.cesto.co/product/ai-leaders
+```
+
+In the URL above, the slug is the final segment: `ai-leaders`. You can also discover slugs programmatically through the Cesto API at `GET /products`.
+
+## Sizing
+
+The plugin's interior uses CSS container queries, so it scales proportionally with whatever pixel width its parent column gives it. The recommended pattern is `width: 100%` plus `aspect-ratio`, letting the page decide width and letting the aspect ratio decide height.
+
+<CodeGroup>
+```html Responsive (recommended)
+<iframe
+  src="https://app.cesto.co/plugin/performance/?basket=ai-leaders"
+  style="width: 100%; aspect-ratio: 15 / 8; border: 0;"
+  loading="lazy"
+></iframe>
+```
+
+```html Fixed pixel size
+<iframe
+  src="https://app.cesto.co/plugin/performance/?basket=ai-leaders"
+  width="900"
+  height="480"
+  style="border: 0;"
+  loading="lazy"
+></iframe>
+```
+</CodeGroup>
+
+A few tips:
+
+- Keep `width: 100%` whenever possible and let the host column drive the width. The plugin will reflow itself.
+- Use `loading="lazy"` for plugins below the fold so the iframe defers until it scrolls into view.
+- The plugin host sets `X-Frame-Options: ALLOWALL` and `frame-ancestors *`, so any origin can embed it.
+
+## What you can change, and what you cannot
+
+Embedding is intentionally minimal. The only knob the host page controls is **size**: width, height, or aspect ratio. Everything else (theme, fonts, copy, behavior, the Invest destination) is fixed by the plugin and stays consistent with the rest of the Cesto product.
+
+If you need anything beyond a Cesto-styled basket card on your page, that is a different surface and not a plugin.
+
+## Next
+
+<CardGroup cols={1}>
+  <Card title="Open the playground" icon="circle-play" href="/plugins/playground">
+    Try every plugin against any live basket, right inside the docs.
+  </Card>
+</CardGroup>

--- a/plugins/usage.mdx
+++ b/plugins/usage.mdx
@@ -9,14 +9,14 @@ This page is everything you need to embed a plugin on your page. The whole integ
 ## The URL
 
 ```
-https://app.cesto.co/plugin/<plugin-url-path>/?basket=<slug>
+https://plugin.cesto.co/<plugin-name>?basket=<slug>
 ```
 
-`<plugin-url-path>` is one of `hero-card`, `performance`, `overview`, or `pill-row`. `<slug>` is the basket's slug, which is the same value used in `app.cesto.co/product/<slug>`.
+`<plugin-name>` is one of `hero-card`, `performance`, `overview`, or `pill-row`. `<slug>` is the basket's slug, which is the same value used in `app.cesto.co/product/<slug>`.
 
 ## The four plugins
 
-| Plugin | `<plugin-url-path>` | Aspect ratio | Min width |
+| Plugin | `<plugin-name>` | Aspect ratio | Min width |
 |---|---|---|---|
 | Hero card | `hero-card` | 5 : 4 | 360 px |
 | Performance | `performance` | 15 : 8 | 540 px |
@@ -27,11 +27,11 @@ Aspect ratio is the recommended shape. Min width is the floor below which the pl
 
 ## Embed snippet
 
-Drop this into any HTML page. Replace `hero-card` and `ai-leaders` with the plugin and basket slug you want.
+Drop this into any HTML page. Replace `hero-card` and `ai-leaders-portfolio` with the plugin and basket slug you want.
 
 ```html
 <iframe
-  src="https://app.cesto.co/plugin/hero-card/?basket=ai-leaders"
+  src="https://plugin.cesto.co/hero-card?basket=ai-leaders-portfolio"
   style="width: 100%; aspect-ratio: 5 / 4; border: 0;"
   loading="lazy"
   title="AI Leaders basket"
@@ -45,10 +45,10 @@ That is the entire integration. The plugin fetches its own data, renders the bas
 Every basket on `app.cesto.co` has a slug in its URL. Open the basket on the website and copy the last path segment, which is the slug:
 
 ```
-https://app.cesto.co/product/ai-leaders
+https://app.cesto.co/product/ai-leaders-portfolio
 ```
 
-In the URL above, the slug is the final segment: `ai-leaders`. You can also discover slugs programmatically through the Cesto API at `GET /products`.
+In the URL above, the slug is the final segment: `ai-leaders-portfolio`. You can also discover slugs programmatically through the Cesto API at `GET /products`.
 
 ## Sizing
 
@@ -57,7 +57,7 @@ The plugin's interior uses CSS container queries, so it scales proportionally wi
 <CodeGroup>
 ```html Responsive (recommended)
 <iframe
-  src="https://app.cesto.co/plugin/performance/?basket=ai-leaders"
+  src="https://plugin.cesto.co/performance?basket=ai-leaders-portfolio"
   style="width: 100%; aspect-ratio: 15 / 8; border: 0;"
   loading="lazy"
 ></iframe>
@@ -65,7 +65,7 @@ The plugin's interior uses CSS container queries, so it scales proportionally wi
 
 ```html Fixed pixel size
 <iframe
-  src="https://app.cesto.co/plugin/performance/?basket=ai-leaders"
+  src="https://plugin.cesto.co/performance?basket=ai-leaders-portfolio"
   width="900"
   height="480"
   style="border: 0;"

--- a/style.css
+++ b/style.css
@@ -1,0 +1,43 @@
+/* ---------------------------------------------------------------------------
+   Cesto docs — custom styling
+   --------------------------------------------------------------------------- */
+
+/* Brand colour over the mint theme ----------------------------------------
+   The mint theme applies the Cesto green (--primary, #4ADE80) to the active
+   nav item, but its hover states fall back to a neutral gray. Force those
+   onto the Cesto green so hovering a page link tints green like the active
+   item, instead of the muted gray mint ships by default.
+
+   Scoped to .sidebar-group (the page links — Overview / Usage / Playground)
+   so the top-level section anchors (Documentation / Developers / Plugins /
+   Website) keep their own treatment and don't get a heavy green bar on hover. */
+.sidebar-group a:hover {
+  color: rgb(74 222 128) !important;
+}
+.sidebar-group a.group:hover {
+  background-color: rgb(74 222 128 / 0.1) !important;
+}
+
+
+/* Plugin playground page: widen the content column so the embedded playground
+   and the page text use the available space instead of sitting in the narrow
+   reading column. Scoped to the playground page via the .cesto-pg-page marker
+   that page renders, so no other page is affected.
+
+   This is done by widening the *column* (not by breaking the iframe out with
+   viewport math), which keeps the page fully responsive — text and iframe
+   share one column width at every breakpoint, and on tablet/mobile the column
+   already spans the freed space once the sidebar collapses to a drawer. */
+
+/* Lift the prose reading-width cap on the playground page only. */
+.mdx-content:has(.cesto-pg-page) {
+  max-width: none;
+}
+
+/* On desktop (>=1280px) the right-hand table-of-contents gutter is empty in
+   wide mode. Bleed the column into it so the playground gets real width. */
+@media (min-width: 1280px) {
+  .mdx-content:has(.cesto-pg-page) {
+    margin-right: -10rem;
+  }
+}


### PR DESCRIPTION
New Plugins section (Overview, Usage, Playground) documenting the embeddable iframe plugins. Switch the theme to mint, render top-level sections as header tabs, apply the Cesto green over the theme, and add style.css for the responsive playground width and brand tweaks.